### PR TITLE
Add Ignite executor to run salmon quant

### DIFF
--- a/conf/local.config
+++ b/conf/local.config
@@ -1,0 +1,5 @@
+docker.enabled = true
+
+executor {
+    name = 'local'
+}

--- a/conf/minimal_salmon_quant_test.config
+++ b/conf/minimal_salmon_quant_test.config
@@ -1,0 +1,21 @@
+/*
+ * -------------------------------------------------
+ *  Nextflow config file for running tests
+ * -------------------------------------------------
+ * Defines bundled input files and everything required
+ * to run a fast and simple test with salmon. Use as follows:
+ *   nextflow run nf-core/rnaseq -profile minimal_salmon_quant_test
+ */
+
+params {
+
+  input = "s3://nf-core-awsmegatests/rnaseq/input_data/minimal/GSE110004/*_[1,2].fastq.gz"
+  fasta = "https://github.com/nf-core/test-datasets/raw/rnaseq/reference/genome.fa"
+  gtf = "https://github.com/nf-core/test-datasets/raw/rnaseq/reference/genes.gtf"
+  gff = "https://github.com/nf-core/test-datasets/raw/rnaseq/reference/genes.gff"
+  transcript_fasta = "https://github.com/nf-core/test-datasets/raw/rnaseq/reference/transcriptome.fasta"
+  additional_fasta = "s3://manu-data-public/rnaseq_files/gfp.fa"
+  umitools_bc_pattern = "NNNN"
+  pseudo_aligner = "salmon"
+  genome = "GRCh38"
+  skip_alignment = true

--- a/conf/standard.config
+++ b/conf/standard.config
@@ -1,0 +1,1 @@
+// This is a reserved config file and must stay empty, please do not edit!

--- a/main.nf
+++ b/main.nf
@@ -1751,7 +1751,8 @@ if (params.pseudo_aligner == 'salmon') {
         tag "$sample"
         publishDir "${params.outdir}/salmon", mode: params.publish_dir_mode
         //publishDir "${params.outdir}/salmon/${sample}", mode: params.publish_dir_mode
-        errorStrategy 'ignore'
+        errorStrategy 'terminate'
+        echo true
         
         input:
         tuple val(sample), path(reads) from trimmed_reads_salmon
@@ -1774,7 +1775,8 @@ if (params.pseudo_aligner == 'salmon') {
         }
         def endedness = params.single_end ? "-r ${reads[0]}" : "-1 ${reads[0]} -2 ${reads[1]}"
         def unmapped = params.save_unaligned ? "--writeUnmappedNames" : ''
-        """
+                """
+                ls -l
         salmon quant \\
             --geneMap $gtf \\
             --threads $task.cpus \\
@@ -1783,6 +1785,7 @@ if (params.pseudo_aligner == 'salmon') {
             $endedness \\
             $unmapped \\
             -o $sample 2>salmon_log_output.err
+            ls -l
         """
     }
 

--- a/main.nf
+++ b/main.nf
@@ -1751,7 +1751,8 @@ if (params.pseudo_aligner == 'salmon') {
         tag "$sample"
         publishDir "${params.outdir}/salmon", mode: params.publish_dir_mode
         //publishDir "${params.outdir}/salmon/${sample}", mode: params.publish_dir_mode
-
+        errorStrategy 'ignore'
+        
         input:
         tuple val(sample), path(reads) from trimmed_reads_salmon
         path index from ch_salmon_index

--- a/main.nf
+++ b/main.nf
@@ -1760,9 +1760,9 @@ if (params.pseudo_aligner == 'salmon') {
         path gtf from ch_gtf
 
         output:
-        tuple val(sample), path("${sample}/") into ( salmon_parsegtf,
+        tuple val(sample), path("${sample}", type: 'dir') into ( salmon_parsegtf,
                                                    salmon_tximport, salmon_logs )
-        //tuple val(sample), path("${sample}/*") into ( salmon_parsegtf,
+        //tuple val(sample), path("${sample}/") into ( salmon_parsegtf,
         //                                           salmon_tximport, salmon_logs )
         //path "${sample}/" into salmon_logs
 

--- a/main.nf
+++ b/main.nf
@@ -1750,6 +1750,7 @@ if (params.pseudo_aligner == 'salmon') {
     process SALMON_QUANT {
         tag "$sample"
         publishDir "${params.outdir}/salmon", mode: params.publish_dir_mode
+        //publishDir "${params.outdir}/salmon/${sample}", mode: params.publish_dir_mode
 
         input:
         tuple val(sample), path(reads) from trimmed_reads_salmon
@@ -1759,6 +1760,8 @@ if (params.pseudo_aligner == 'salmon') {
         output:
         tuple val(sample), path("${sample}/") into ( salmon_parsegtf,
                                                    salmon_tximport, salmon_logs )
+        //tuple val(sample), path("${sample}/*") into ( salmon_parsegtf,
+        //                                           salmon_tximport, salmon_logs )
         //path "${sample}/" into salmon_logs
 
         script:
@@ -1778,7 +1781,7 @@ if (params.pseudo_aligner == 'salmon') {
             --index $index \\
             $endedness \\
             $unmapped \\
-            -o $sample
+            -o $sample 2>salmon_log_output.err
         """
     }
 

--- a/main.nf
+++ b/main.nf
@@ -1757,9 +1757,9 @@ if (params.pseudo_aligner == 'salmon') {
         path gtf from ch_gtf
 
         output:
-        tuple val(sample), path("${sample}/") into salmon_parsegtf,
-                                                   salmon_tximport
-        path "${sample}/" into salmon_logs
+        tuple val(sample), path("${sample}/") into ( salmon_parsegtf,
+                                                   salmon_tximport, salmon_logs )
+        //path "${sample}/" into salmon_logs
 
         script:
         def rnastrandness = params.single_end ? 'U' : 'IU'
@@ -1919,7 +1919,7 @@ process MULTIQC {
     path ('featurecounts/*') from featureCounts_logs.collect().ifEmpty([])
     path ('featurecounts_biotype/*') from featureCounts_biotype.collect().ifEmpty([])
     path ('rsem/*') from rsem_logs.collect().ifEmpty([])
-    path ('salmon/*') from salmon_logs.collect().ifEmpty([])
+    path ('salmon/*') from salmon_logs.collect{it[1]}.ifEmpty([])
     path ('sample_correlation/*') from sample_correlation_results.collect().ifEmpty([])
     path ('sortmerna/*') from sortmerna_logs.collect().ifEmpty([])
     //path ('software_versions/*') from ch_software_versions_yaml.collect()

--- a/main.nf
+++ b/main.nf
@@ -1750,9 +1750,6 @@ if (params.pseudo_aligner == 'salmon') {
     process SALMON_QUANT {
         tag "$sample"
         publishDir "${params.outdir}/salmon", mode: params.publish_dir_mode
-        //publishDir "${params.outdir}/salmon/${sample}", mode: params.publish_dir_mode
-        errorStrategy 'terminate'
-        echo true
         
         input:
         tuple val(sample), path(reads) from trimmed_reads_salmon
@@ -1762,10 +1759,7 @@ if (params.pseudo_aligner == 'salmon') {
         output:
         tuple val(sample), path("${sample}", type: 'dir') into ( salmon_parsegtf,
                                                    salmon_tximport, salmon_logs )
-        //tuple val(sample), path("${sample}/") into ( salmon_parsegtf,
-        //                                           salmon_tximport, salmon_logs )
-        //path "${sample}/" into salmon_logs
-
+        
         script:
         def rnastrandness = params.single_end ? 'U' : 'IU'
         if (forward_stranded && !unstranded) {
@@ -1776,7 +1770,6 @@ if (params.pseudo_aligner == 'salmon') {
         def endedness = params.single_end ? "-r ${reads[0]}" : "-1 ${reads[0]} -2 ${reads[1]}"
         def unmapped = params.save_unaligned ? "--writeUnmappedNames" : ''
                 """
-                ls -l
         salmon quant \\
             --geneMap $gtf \\
             --threads $task.cpus \\
@@ -1784,8 +1777,7 @@ if (params.pseudo_aligner == 'salmon') {
             --index $index \\
             $endedness \\
             $unmapped \\
-            -o $sample 2>salmon_log_output.err
-            ls -l
+            -o $sample
         """
     }
 

--- a/main.nf
+++ b/main.nf
@@ -907,7 +907,7 @@ if (params.with_umi) {
 if (!params.skip_trimming) {
     process TRIMGALORE {
         tag "$name"
-        label 'process_high'
+        label 'process_low'
         publishDir "${params.outdir}/trimgalore", mode: params.publish_dir_mode,
             saveAs: { filename ->
                 if (filename.indexOf("_fastqc") > 0) "fastqc/$filename"
@@ -1059,7 +1059,7 @@ if (!params.skip_alignment) {
         hisat_stdout = Channel.empty()
         process STAR_ALIGN {
             tag "$name"
-            label 'high_memory'
+            label 'process_low'
             publishDir "${params.outdir}/star", mode: params.publish_dir_mode,
                 saveAs: { filename ->
                     if (filename.indexOf(".bam") == -1) "logs/$filename"

--- a/nextflow.config
+++ b/nextflow.config
@@ -123,6 +123,13 @@ params {
 
   // configuration related params
   config = 'conf/google.config'
+  config = 'conf/standard.config'
+  echo = false
+  errorStrategy = 'finish'
+  maxRetries = 9
+  maxForks = 200
+  queueSize = 200
+  executor = false
 }
 
 // Container slug. Stable releases should specify release tag!
@@ -131,6 +138,7 @@ process.container = 'lifebitai/nf-core-rnaseq:1.4.3dev'
 
 // Load base.config by default for all pipelines
 includeConfig 'conf/base.config'
+docker.enabled = true
 
 // Load nf-core custom profiles from different Institutions
 try {
@@ -234,4 +242,9 @@ def check_max(obj, type) {
       return obj
     }
   }
+}
+
+executor {
+    name = params.executor
+    queueSize = params.queueSize
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -12,6 +12,7 @@ params {
   // Workflow flags
   input = "data/*{1,2}.fastq.gz"
   single_end = false
+  input_paths = false
 
   // References
   genome = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -163,6 +163,7 @@ profiles {
     singularity.enabled = true
     singularity.autoMounts = true
   }
+  minimal_salmon_quant_test { includeConfig 'conf/minimal_salmon_quant_test.config' }
   test      { includeConfig 'conf/test.config'      }
   test_full { includeConfig 'conf/test_full.config' }
   test_gz   { includeConfig 'conf/test_gz.config'   }


### PR DESCRIPTION
## Overview

The main purpose of this PR is to adapt the nf-core RNAseq pipeline to run with ignite executor and produce read count files through the salmon quantification process.

## Purpose

To achieve that we modified some pipeline configuration options to allow it to run on CloudOS and create the salmon quantification files.

## Changes

- Adds local.config and standard config files
- Refactor salmon_quant process in main.nf
- Change memory requirements in main.nf
- Adds executor in nextflow.config

## Testing

In order to run the script locally:

- Clone the repository:
```
git clone https://github.com/lifebit-ai/nf-rnaseq-salmon.git
cd nf-rnaseq-salmon
git checkout manu_add_ignite
```
- Execute the nextflow pipeline
``` 
 NXF_VER=20.04.1 nextflow run . --input s3://nf-core-awsmegatests/rnaseq/input_data/minimal/GSE110004/*_[1,2].fastq.gz --fasta https://github.com/nf-core/test-datasets/raw/rnaseq/reference/genome.fa --gtf https://github.com/nf-core/test-datasets/raw/rnaseq/reference/genes.gtf --gff https://github.com/nf-core/test-datasets/raw/rnaseq/reference/genes.gff --transcript_fasta https://github.com/nf-core/test-datasets/raw/rnaseq/reference/transcriptome.fasta --additional_fasta s3://manu-data-public/rnaseq_files/gfp.fa --umitools_bc_pattern NNNN --pseudo_aligner salmon --genome GRCh38 --skip_alignment
```
Results:
The pipeline will generate the read count files in the results folder

CloudOS test run: 
https://cloudos.lifebit.ai/public/jobs/61dd84f38c574a01e8d6c9cd
