### PR TITLE
Add option to provide sample table as input

### DIFF
--- a/conf/minimal_salmon_quant_test.config
+++ b/conf/minimal_salmon_quant_test.config
@@ -19,3 +19,4 @@ params {
   pseudo_aligner = "salmon"
   genome = "GRCh38"
   skip_alignment = true
+}


### PR DESCRIPTION
## Overview

Adds option to provide a csv file to `--input` which lists the sample names and paths for each fastq file or pair of fastq files. The csv file must have a header line with the columns `sample`, `fastq_1`, (and `fastq_2` if the reads are paired).

## Changes

- The pipeline detects if the value of `params.input` is a file with a .csv extension and if so reads the rows of the csv to get input files.

## Testing

Successful run on cloudos.
https://cloudos.lifebit.ai/app/jobs/61e1bcb08c574a01e8d83e62

Local testing
```
git clone https://github.com/lifebit-ai/nf-rnaseq-salmon
cd nf-rnaseq-salmon
git checkout add-samplesheet-input
NXF_VER=20.04.1 nextflow run main.nf --config conf/minimal_salmon_quant_test.config --input s3://ilevantis-bucket/rnaseq-salmon/samples.csv
```